### PR TITLE
Replace instance of numpy.int in face detection to make compatible with modern versions of NumPy

### DIFF
--- a/face_detection.py
+++ b/face_detection.py
@@ -21,7 +21,7 @@ def face_points_detection(img, bbox:dlib.rectangle):
 
     # loop over the 68 facial landmarks and convert them
     # to a 2-tuple of (x, y)-coordinates
-    coords = np.asarray(list([p.x, p.y] for p in shape.parts()), dtype=np.int)
+    coords = np.asarray(list([p.x, p.y] for p in shape.parts()), dtype=int)
 
     # return the array of (x, y)-coordinates
     return coords


### PR DESCRIPTION
The deprecation for alias `np.int` expired in v1.24 ([see here](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations)).

It's safe to just use `int`. This PR changes a single line in `face_detection.py` which solves the issue.

Resolves #45 